### PR TITLE
[# 259939] Add warning for long-running remote calls

### DIFF
--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/Activator.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/Activator.java
@@ -18,19 +18,14 @@
  */
 package org.apache.aries.rsa.provider.fastbin;
 
-import java.util.Dictionary;
 import java.util.Hashtable;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.aries.rsa.provider.fastbin.io.ClientInvoker;
 import org.apache.aries.rsa.provider.fastbin.io.ServerInvoker;
-import org.apache.aries.rsa.provider.fastbin.util.UuidGenerator;
-import org.apache.aries.rsa.spi.DistributionProvider;
 import org.osgi.annotation.bundle.Capability;
 import org.osgi.annotation.bundle.Header;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
-import org.osgi.service.cm.ManagedService;
 import org.osgi.service.remoteserviceadmin.RemoteConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/FastBinProvider.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/FastBinProvider.java
@@ -18,17 +18,13 @@
  */
 package org.apache.aries.rsa.provider.fastbin;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.net.Inet4Address;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.aries.rsa.provider.fastbin.api.FastbinEndpoint;
@@ -38,10 +34,8 @@ import org.apache.aries.rsa.provider.fastbin.io.ServerInvoker;
 import org.apache.aries.rsa.provider.fastbin.tcp.ClientInvokerImpl;
 import org.apache.aries.rsa.provider.fastbin.tcp.ServerInvokerImpl;
 import org.apache.aries.rsa.provider.fastbin.tcp.TcpTransportServer;
-import org.apache.aries.rsa.provider.fastbin.util.UuidGenerator;
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.Endpoint;
-import org.apache.aries.rsa.spi.IntentUnsatisfiedException;
 import org.fusesource.hawtdispatch.Dispatch;
 import org.fusesource.hawtdispatch.DispatchQueue;
 import org.osgi.framework.BundleContext;
@@ -120,7 +114,7 @@ public class FastBinProvider implements DistributionProvider {
             {
                 uri += "?"+TcpTransportServer.BIND_ADDRESS_QUERY_PARAM+"="+bindAddress;
             }
-            server = new ServerInvokerImpl(uri, queue, serializationStrategies);
+            server = new ServerInvokerImpl(uri, queue, serializationStrategies, timeout);
             client = new ClientInvokerImpl(queue, timeout, serializationStrategies);
             client.start();
         } catch (Exception e) {

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
@@ -89,6 +89,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
     protected final TransportServer server;
     protected final Map<UTF8Buffer, ServiceFactoryHolder> holders = new ConcurrentHashMap<>();
     private StreamProviderImpl streamProvider;
+    private final ServerResponseThresholdTracker responseThresholdTracker;
 
     static class MethodData {
 
@@ -164,11 +165,16 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
     }
 
     public ServerInvokerImpl(String address, DispatchQueue queue, Map<String, SerializationStrategy> serializationStrategies) throws Exception {
+        this(address, queue, serializationStrategies, -1);
+    }
+
+    public ServerInvokerImpl(String address, DispatchQueue queue, Map<String, SerializationStrategy> serializationStrategies, long clientTimeout) throws Exception {
         this.queue = queue;
         this.serializationStrategies = serializationStrategies;
         this.server = new TcpTransportFactory().bind(address);
         this.server.setDispatchQueue(queue);
         this.server.setAcceptListener(new InvokerAcceptListener());
+        this.responseThresholdTracker = new ServerResponseThresholdTracker(clientTimeout);
     }
 
     public InetSocketAddress getSocketAddress() {
@@ -240,6 +246,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
         this.server.stop(new Runnable() {
             public void run() {
                 blockingExecutor.shutdown();
+                responseThresholdTracker.close();
                 if (onComplete != null) {
                     onComplete.run();
                 }
@@ -266,14 +273,19 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
                 task = new SendTask(bais, correlation, transport, message);
             }
             final Object svc = holder==null ? null : holder.factory.get();
+            String trackClass  = "unknown";
+            String trackMethod = encoded_method.utf8().toString();
             if(holder!=null) {
                 try {
                     final MethodData methodData = holder.getMethodData(encoded_method);
                     task = new SendTask(svc, bais, holder, correlation, methodData, transport);
+                    if (methodData.method != null) {
+                        trackClass  = methodData.method.getDeclaringClass().getSimpleName();
+                        trackMethod = methodData.method.getName();
+                    }
                 }
                 catch (ReflectiveOperationException reflectionEx) {
-                    final String methodName = encoded_method.utf8().toString();
-                    String message = "The requested method {"+methodName+"} is not available";
+                    String message = "The requested method {"+trackMethod+"} is not available";
                     LOGGER.warn(message);
                     task = new SendTask(bais, correlation, transport, message);
                 }
@@ -285,6 +297,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
             } else {
                 executor = blockingExecutor;
             }
+            responseThresholdTracker.track(correlation, trackClass, trackMethod);
             executor.execute(task);
 
         } catch (Exception e) {
@@ -365,6 +378,8 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
             } catch (IOException e) { // should not happen
                 LOGGER.error("Failed to write to buffer", e);
                 throw new RuntimeException(e);
+            }finally {
+                responseThresholdTracker.complete(correlation);
             }
 
             // Let's decode the remaining args on the target's executor
@@ -373,19 +388,25 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
             ClassLoader loader = holder==null ? getClass().getClassLoader() : holder.loader;
             methodData.invocationStrategy.service(methodData.serializationStrategy, loader, methodData.method, svc, bais, baos, new Runnable() {
                 public void run() {
-                    if(holder!=null)
-                        holder.factory.unget();
-                    final Buffer command = baos.toBuffer();
+                    try {
+                        if (holder!=null)
+                            holder.factory.unget();
+                        final Buffer command = baos.toBuffer();
 
-                    // Update the size field.
-                    BufferEditor editor = command.buffer().bigEndianEditor();
-                    editor.writeInt(command.length);
+                        // Update the size field.
+                        BufferEditor editor = command.buffer().bigEndianEditor();
+                        editor.writeInt(command.length);
 
-                    queue().execute(new Runnable() {
-                        public void run() {
-                            transport.offer(command);
-                        }
-                    });
+                        queue().execute(new Runnable() {
+                            public void run() {
+                                transport.offer(command);
+                                responseThresholdTracker.complete(correlation);
+                            }
+                        });
+                    } catch (Exception e) {
+                        responseThresholdTracker.complete(correlation);
+                        throw e;
+                    }
                 }
             });
         }

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.aries.rsa.provider.fastbin.tcp;
+
+import java.io.Closeable;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks in-flight {@code SendTask} executions and emits log entries when their
+ * execution time exceeds configured thresholds.
+ *
+ * <p>
+ * When a task is registered via {@link #track} two {@link TimerTask}s are
+ * scheduled on a single shared daemon {@link Timer}:
+ * <ol>
+ * <li>fires after the configured warning threshold – logs a WARN</li>
+ * <li>fires after the live client timeout returned by
+ * {@code Activator.getInstance().getClient().getTimeout()} – logs an ERROR
+ * indicating the server has exceeded the client timeout and the client has
+ * likely already given up waiting for this response</li>
+ * </ol>
+ * Both tasks are cancelled immediately when {@link #complete} is called, so
+ * fast calls produce no log output at all.
+ *
+ * <p>
+ * Call {@link #close()} when the owning component stops to cancel the shared
+ * timer and all pending tasks.
+ */
+final class ServerResponseThresholdTracker implements Closeable {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ServerResponseThresholdTracker.class);
+
+	/**
+	 * Single shared daemon timer – one thread services all threshold tasks per
+	 * request.
+	 */
+	private final Timer timer = new Timer("rsa-threshold-monitor", true);
+
+	/** Active tasks keyed by correlation id. */
+	private final ConcurrentMap<Long, TrackedEntry> activeTasks = new ConcurrentHashMap<>();
+
+	/**
+	 * Duration after which a running server-side call issues a WARN. Configurable
+	 * via system property
+	 * {@code org.apache.aries.rsa.provider.fastbin.tcpthreshold.warn.ms}. Default
+	 * half of the client timeout threshold.
+	 */
+	private final long thresholdWarningMs;
+
+	/**
+	 * Client-side request timeout passed in at construction time from
+	 * {@code ServerInvokerImpl}, which receives it from {@code FastBinProvider}.
+	 */
+	private final long clientTimeout;
+
+	/** Flag to disable all tracking and logging when client timeout is non-positive. */
+	private boolean turnedOn = true;
+
+	/**
+	 * Production constructor – reads the warning threshold from the system
+	 * property.
+	 *
+	 * @param clientTimeout
+	 *            the client-side request timeout in milliseconds; should match
+	 *            {@code ClientInvokerImpl}'s configured timeout
+	 */
+	ServerResponseThresholdTracker(long clientTimeout) {
+		this(Long.getLong("org.apache.aries.rsa.provider.fastbin.tcpthreshold.warn.ms", clientTimeout / 2),
+			 clientTimeout);
+
+		if (clientTimeout <= 0) {
+			turnedOn = false;
+			LOGGER.info("Client timeout is non-positive ({} ms) – response threshold tracking disabled", clientTimeout);
+		}
+	}
+
+	/**
+	 * Package-private constructor for unit tests – accepts explicit threshold
+	 * values so tests can use short delays without touching system properties.
+	 *
+	 * @param thresholdWarningMs
+	 *            duration in ms before a WARN is logged
+	 * @param clientTimeout
+	 *            duration in ms before an ERROR is logged (mirrors client timeout)
+	 */
+	ServerResponseThresholdTracker(long thresholdWarningMs, long clientTimeout) {
+		this.thresholdWarningMs = thresholdWarningMs;
+		this.clientTimeout = clientTimeout;
+	}
+
+	private static final class TrackedEntry {
+		final TimerTask warnTask;
+		final TimerTask errorTask;
+
+		TrackedEntry(TimerTask warnTask, TimerTask errorTask) {
+			this.warnTask = warnTask;
+			this.errorTask = errorTask;
+		}
+	}
+
+	/**
+	 * Registers a {@code SendTask} as in-flight and schedules all three threshold
+	 * checks. Must be called in {@code ServerInvokerImpl.onCommand()} before
+	 * submitting the task to the executor.
+	 *
+	 * @param correlationId
+	 *            unique request correlation id
+	 * @param className
+	 *            simple name of the service class ({@code "unknown"} if
+	 *            unavailable)
+	 * @param methodName
+	 *            name of the invoked method ({@code "unknown"} if unavailable)
+	 */
+	void track(final long correlationId, final String className, final String methodName) {
+		if (!turnedOn) {
+			return;
+		}
+
+		TimerTask warnTask = new TimerTask() {
+			@Override
+			public void run() {
+				LOGGER.warn("Remote call still running after {}ms , method: {}.{}", thresholdWarningMs, className,
+						methodName);
+			}
+		};
+
+		TimerTask errorTask = new TimerTask() {
+			@Override
+			public void run() {
+				LOGGER.error(
+						"Remote call still running after {}ms - client timeout reached. "
+								+ "Client may have already abandoned the request, method: {}.{}",
+						clientTimeout, className, methodName);
+			}
+		};
+
+		activeTasks.put(correlationId, new TrackedEntry(warnTask, errorTask));
+		timer.schedule(warnTask, thresholdWarningMs);
+		timer.schedule(errorTask, clientTimeout);
+	}
+
+	/**
+	 * Cancels all pending threshold tasks for the given correlation id. If the call
+	 * finishes before any threshold is reached no log entry is produced. Must be
+	 * called inside the {@code SendTask}'s completion callback {@code finally}
+	 * block.
+	 *
+	 * @param correlationId
+	 *            unique request correlation id
+	 */
+	void complete(long correlationId) {
+		if (!turnedOn) {
+			return;
+		}
+		TrackedEntry entry = activeTasks.remove(correlationId);
+		if (entry != null) {
+			entry.warnTask.cancel();
+			entry.errorTask.cancel();
+		}
+	}
+
+	/**
+	 * Cancels the shared timer and all pending threshold tasks. Must be called when
+	 * the owning {@code ServerInvokerImpl} stops.
+	 */
+	@Override
+	public void close() {
+		timer.cancel();
+		activeTasks.clear();
+	}
+}

--- a/provider/fastbin/src/test/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTrackerTest.java
+++ b/provider/fastbin/src/test/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTrackerTest.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.aries.rsa.provider.fastbin.tcp;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ServerResponseThresholdTracker}.
+ *
+ * <p>
+ * Uses the two-arg package-private constructor so that millisecond-level delays
+ * can be used instead of the production 10s / 20s values.
+ *
+ * <p>
+ * Threshold values chosen:
+ * <ul>
+ * <li>warning = 80 ms</li>
+ * <li>error (client timeout) = 200 ms</li>
+ * </ul>
+ * Awaitility polls for at most 2 seconds so tests fail fast on regressions.
+ */
+public class ServerResponseThresholdTrackerTest {
+	/** Warning threshold used across all tests (ms). */
+	private static final long WARN_MS = 80L;
+	/** Error/client-timeout threshold used across all tests (ms). */
+	private static final long TIMEOUT_MS = 200L;
+
+	private static final String CLASS_NAME = "MyService";
+	private static final String METHOD_NAME = "myMethod";
+	private static final long CORR_ID = 1L;
+
+	private ServerResponseThresholdTracker tracker;
+
+	/** Logback in-memory appender for the class under test. */
+	private ListAppender<ILoggingEvent> appender;
+	private Logger trackerLogger;
+
+	@Before
+	public void setUp() {
+		tracker = new ServerResponseThresholdTracker(WARN_MS, TIMEOUT_MS);
+
+		appender = new ListAppender<>();
+		appender.start();
+		trackerLogger = (Logger) LoggerFactory.getLogger(ServerResponseThresholdTracker.class);
+		trackerLogger.addAppender(appender);
+	}
+
+	@After
+	public void tearDown() {
+		trackerLogger.detachAppender(appender);
+		tracker.close();
+	}
+
+	private List<ILoggingEvent> logsAtLevel(Level level) {
+		return appender.list.stream().filter(e -> e.getLevel() == level).collect(Collectors.toList());
+	}
+
+	/**
+	 * A task that completes well before the warning threshold must not produce any
+	 * log output.
+	 */
+	@Test
+	public void completingBeforeWarningProducesNoLogs() throws Exception {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+		tracker.complete(CORR_ID);
+
+		// wait past both thresholds to be sure nothing fires
+		Thread.sleep(TIMEOUT_MS + 100);
+
+		assertThat(appender.list, is(empty()));
+	}
+
+	/**
+	 * A task still running after {@code WARN_MS} must produce exactly one WARN
+	 * entry.
+	 */
+	@Test
+	public void warnIsLoggedWhenWarningThresholdExceeded() {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+
+		await().atMost(2, TimeUnit.SECONDS).until(() -> !logsAtLevel(Level.WARN).isEmpty());
+
+		assertThat(logsAtLevel(Level.WARN), hasSize(1));
+		assertThat(logsAtLevel(Level.ERROR), is(empty()));
+
+		tracker.complete(CORR_ID);
+	}
+
+	/**
+	 * A task still running after {@code TIMEOUT_MS} must produce an ERROR entry (in
+	 * addition to the earlier WARN).
+	 */
+	@Test
+	public void errorIsLoggedWhenClientTimeoutExceeded() {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+
+		await().atMost(2, TimeUnit.SECONDS).until(() -> !logsAtLevel(Level.ERROR).isEmpty());
+
+		assertThat(logsAtLevel(Level.WARN), hasSize(1));
+		assertThat(logsAtLevel(Level.ERROR), hasSize(1));
+
+		tracker.complete(CORR_ID);
+	}
+
+	/**
+	 * Completing a task after the WARN has fired but before the ERROR fires must
+	 * cancel the pending ERROR task – so only the WARN entry appears.
+	 */
+	@Test
+	public void completingAfterWarnButBeforeErrorCancelsErrorTask() throws Exception {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+
+		// wait until the warning has fired
+		await().atMost(2, TimeUnit.SECONDS).until(() -> !logsAtLevel(Level.WARN).isEmpty());
+
+		tracker.complete(CORR_ID);
+
+		// wait past the point where the error would have fired
+		Thread.sleep(TIMEOUT_MS + 100);
+
+		assertThat(logsAtLevel(Level.WARN), hasSize(1));
+		assertThat(logsAtLevel(Level.ERROR), is(empty()));
+	}
+
+	/**
+	 * Calling {@link ServerResponseThresholdTracker#complete} with a correlation id
+	 * that was never tracked must not throw.
+	 */
+	@Test
+	public void completeWithUnknownCorrelationIdDoesNotThrow() {
+		tracker.complete(999L); // never tracked – must be a no-op
+	}
+
+	/**
+	 * Calling {@link ServerResponseThresholdTracker#close} must cancel all pending
+	 * timer tasks so that no log entries appear afterwards.
+	 */
+	@Test
+	public void closePreventsPendingTasksFromFiring() throws Exception {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+		tracker.close();
+
+		Thread.sleep(TIMEOUT_MS + 100);
+
+		assertThat(appender.list, is(empty()));
+	}
+
+	/**
+	 * Log messages must include the class and method names passed to
+	 * {@link ServerResponseThresholdTracker#track}.
+	 */
+	@Test
+	public void logMessagesContainClassAndMethodName() {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+
+		await().atMost(2, TimeUnit.SECONDS).until(() -> !logsAtLevel(Level.WARN).isEmpty());
+
+		String msg = logsAtLevel(Level.WARN).get(0).getFormattedMessage();
+		assertThat(msg, containsString(CLASS_NAME));
+		assertThat(msg, containsString(METHOD_NAME));
+
+		tracker.complete(CORR_ID);
+	}
+
+	/**
+	 * Multiple concurrent tasks must be tracked independently: completing one must
+	 * not cancel the timers of the others.
+	 */
+	@Test
+	public void multipleTasksTrackedIndependently() throws Exception {
+		tracker.track(1L, "ServiceA", "methodA");
+		tracker.track(2L, "ServiceB", "methodB");
+		tracker.track(3L, "ServiceC", "methodC");
+
+		// complete task 2 immediately – its timers must be cancelled
+		tracker.complete(2L);
+
+		// wait until warnings fire for tasks 1 and 3
+		await().atMost(2, TimeUnit.SECONDS).until(() -> logsAtLevel(Level.WARN).size() >= 2);
+
+		long warnForA = logsAtLevel(Level.WARN).stream().filter(e -> e.getFormattedMessage().contains("methodA"))
+				.count();
+		long warnForB = logsAtLevel(Level.WARN).stream().filter(e -> e.getFormattedMessage().contains("methodB"))
+				.count();
+		long warnForC = logsAtLevel(Level.WARN).stream().filter(e -> e.getFormattedMessage().contains("methodC"))
+				.count();
+
+		assertEquals("task A should have warned", 1L, warnForA);
+		assertEquals("task B was completed early – no warn expected", 0L, warnForB);
+		assertEquals("task C should have warned", 1L, warnForC);
+
+		tracker.complete(1L);
+		tracker.complete(3L);
+	}
+
+	/**
+	 * Calling {@link ServerResponseThresholdTracker#complete} twice for the same
+	 * correlation id must be a no-op on the second call.
+	 */
+	@Test
+	public void completeIsIdempotent() throws Exception {
+		tracker.track(CORR_ID, CLASS_NAME, METHOD_NAME);
+		tracker.complete(CORR_ID);
+		tracker.complete(CORR_ID); // second call must not throw
+
+		Thread.sleep(TIMEOUT_MS + 100);
+
+		assertThat(appender.list, is(empty()));
+	}
+}


### PR DESCRIPTION
Messages will be logged in their own thread. This way, they will not depend on when/if the SendTask gets executed.