### PR TITLE
Server side response tracking is removed too early

### DIFF
--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
@@ -376,10 +376,9 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
                 baos.writeInt(0); // make space for the size field.
                 baos.writeVarLong(correlation);
             } catch (IOException e) { // should not happen
+                responseThresholdTracker.complete(correlation);
                 LOGGER.error("Failed to write to buffer", e);
                 throw new RuntimeException(e);
-            }finally {
-                responseThresholdTracker.complete(correlation);
             }
 
             // Let's decode the remaining args on the target's executor


### PR DESCRIPTION
The dispatch thread is not the one removing the tracked entry. That's probably why we do not see the log msgs