### PR TITLE
[Bug #271417] - Introduce server response tracker invocation strategy discrimination

### DIFF
--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerInvokerImpl.java
@@ -267,6 +267,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
 
             final ServiceFactoryHolder holder = holders.get(service);
             Runnable task = null;
+            boolean clientAbandonmentLikely = true;
             if(holder==null) {
                 String message = "The requested service {"+service+"} is not available";
                 LOGGER.warn(message);
@@ -279,6 +280,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
                 try {
                     final MethodData methodData = holder.getMethodData(encoded_method);
                     task = new SendTask(svc, bais, holder, correlation, methodData, transport);
+                    clientAbandonmentLikely = methodData.invocationStrategy instanceof BlockingInvocationStrategy;
                     if (methodData.method != null) {
                         trackClass  = methodData.method.getDeclaringClass().getSimpleName();
                         trackMethod = methodData.method.getName();
@@ -297,7 +299,7 @@ public class ServerInvokerImpl implements ServerInvoker, Dispatched {
             } else {
                 executor = blockingExecutor;
             }
-            responseThresholdTracker.track(correlation, trackClass, trackMethod);
+            responseThresholdTracker.track(correlation, trackClass, trackMethod, clientAbandonmentLikely);
             executor.execute(task);
 
         } catch (Exception e) {

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
@@ -158,7 +158,7 @@ final class ServerResponseThresholdTracker implements Closeable {
 									+ "Client may have already abandoned the request, method: {}.{}",
 							clientTimeout, className, methodName);
 				} else {
-					LOGGER.warn("Remote async call still running after {}ms - client timeout reached, method: {}.{}",
+					LOGGER.warn("Remote async call still running after {}ms, method: {}.{}",
 							clientTimeout, className, methodName);
 				}
 			}

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/tcp/ServerResponseThresholdTracker.java
@@ -131,8 +131,12 @@ final class ServerResponseThresholdTracker implements Closeable {
 	 *            unavailable)
 	 * @param methodName
 	 *            name of the invoked method ({@code "unknown"} if unavailable)
+	 * @param clientAbandonmentLikely
+	 *            whether reaching the timeout likely means the client has abandoned
+	 *            waiting (typically true for blocking calls, false for async
+	 *            invocations)
 	 */
-	void track(final long correlationId, final String className, final String methodName) {
+	void track(final long correlationId, final String className, final String methodName, final boolean clientAbandonmentLikely) {
 		if (!turnedOn) {
 			return;
 		}
@@ -148,10 +152,15 @@ final class ServerResponseThresholdTracker implements Closeable {
 		TimerTask errorTask = new TimerTask() {
 			@Override
 			public void run() {
-				LOGGER.error(
-						"Remote call still running after {}ms - client timeout reached. "
-								+ "Client may have already abandoned the request, method: {}.{}",
-						clientTimeout, className, methodName);
+				if (clientAbandonmentLikely) {
+					LOGGER.error(
+							"Remote call still running after {}ms - client timeout reached. "
+									+ "Client may have already abandoned the request, method: {}.{}",
+							clientTimeout, className, methodName);
+				} else {
+					LOGGER.warn("Remote async call still running after {}ms - client timeout reached, method: {}.{}",
+							clientTimeout, className, methodName);
+				}
 			}
 		};
 


### PR DESCRIPTION
A lot of error log msgs from the ServerResponseThresholdTracker are emitted when the async invocation strategy is used.

Sth. like

ERROR org.apache.aries.rsa.provider.fastbin.tcp.ServerResponseThresholdTracker rsa-threshold-monitor [org.apache.aries.rsa.provider.fastbin:1.17.1.SEE70] Remote call still running after 20000ms - client timeout reached. Client may have already abandoned the request, method: DefaultCollectorService.collect


This should not happen as the async strategy is utilised exactly for these cases.

We end up with a lot of misleading logs when analysing client issues


If the remote method’s return type is Future, it uses AsyncFutureInvocationStrategy automatically (InvocationType checks Future first).
What happens then:
1. Server side: method is invoked and expected to return a Future.  
◦If it’s already a CompletableFuture, it hooks whenComplete(...).
◦Otherwise, it wraps it with an internal completer thread that waits for completion.
◦The reply is sent only when that future completes (value or exception).
2. Client side: the proxy call still goes through request(...), but for this strategy the internal ResponseFuture.get(...) returns a CompletableFuture immediately (it does not block for remote completion).  
• So the caller gets a Future right away.
◦When the server response arrives, that future is completed or completed exceptionally.
The API returns immediately with a Future, and completion is propagated later from the remote side.

However, the ServerResponseThresholdTracker starts a timer for every request and logs after clientTimeout (default 20000ms) if that response hasn’t been sent yet.
So the log can appear even for async Future calls: the client got a Future instantly, but that Future remained unresolved for>20s.

